### PR TITLE
Add config options for line length

### DIFF
--- a/lib/overflow-editor-view.coffee
+++ b/lib/overflow-editor-view.coffee
@@ -61,8 +61,11 @@ class OverflowEditorView
       @views.push(view)
 
   getPreferredLineLength: ->
-    atom.config.get('editor.preferredLineLength',
-      scope: @editor.getRootScopeDescriptor())
+    if atom.config.get('overflow.usePreferredLineLength')
+      atom.config.get('editor.preferredLineLength',
+        scope: @editor.getRootScopeDescriptor())
+    else
+      atom.config.get('overflow.column')
 
   updateOverflows: ->
     # Task::start can throw errors atom/atom#3326
@@ -73,3 +76,4 @@ class OverflowEditorView
         @addViews(overflows) if @buffer?
     catch error
       console.warn('Error starting overflow task', error.stack ? error)
+

--- a/lib/overflow.coffee
+++ b/lib/overflow.coffee
@@ -2,8 +2,26 @@ OverflowEditorView = null
 views = []
 
 module.exports =
+  config:
+    usePreferredLineLength:
+      type: 'boolean'
+      default: true
+      description: """Use the editor's preferred line length
+                      (overrides the 'Column' setting below)"""
+      order: 1
+    column:
+      type: 'integer'
+      default: 80
+      minimum: 0
+      maximum: 500
+      order: 2
+
   activate: ->
     @disposable = atom.workspace.observeTextEditors(@addViewToEditor)
+    atom.config.observe 'overflow.usePreferredLineLength', (enabled) ->
+      console.log 'overflow.usePreferredLineLength:', enabled
+    atom.config.observe 'overflow.column', (column) ->
+      console.log 'overflow.column:', column
 
   deactivate: ->
     @disposable.dispose()
@@ -14,3 +32,4 @@ module.exports =
   addViewToEditor: (editor) ->
     OverflowEditorView ?= require './overflow-editor-view'
     views.push new OverflowEditorView(editor)
+


### PR DESCRIPTION
Thanks for a great package!

I like to have a "preferred" line length (80) and I _try_ to keep everything below it. If the code goes just a bit over it, or if a line change makes the code look uglier, I leave the line over 80 characters long.

But I also have a "maximum" line length (100), which I always stay below, no matter what (because lines this long are horrible to read).

This PR adds config options for whether to use Atom's preferred line length or a custom "maximum" line length. This way Atom's preferred line length and this package's "maximum" line length can be independent of each other.

---

I noticed that the overflow doesn't trigger for files that are already open when you launch Atom (files from a saved session). You have to either modify or re-open the file for the overflow to work. This is an unrelated bug, and wasn't introduced in this PR.

Related to the above bug; this is still WIP. Changing the config options also requires editing or re-opening the file. I added observers for the config options, but currently they only print a log message. Do you mind continuing from here?
